### PR TITLE
Edited Hugo configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,13 +14,13 @@ googleAnalytics = "UA-56802475-3"
 
 [mediaTypes]
 [mediaTypes."text/markdown"]
-suffix = "md"
+suffixes = ["md"]
 
 [mediaTypes."text/plain"]
-suffix = "txt"
+suffixes = ["txt"]
 
 [mediaTypes."text/asciidoc"]
-suffix = "adoc"
+suffixes = ["adoc"]
 
 [outputFormats]
 [outputFormats.Markdown]


### PR DESCRIPTION
When a new contributor tries to run the project Hugo will throw the following error:
```
Error: from config: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way
to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").
This had its limitations. For one, it was only possible with one file extension per MIME type.

Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
identifier:

[mediaTypes]
[mediaTypes."image/svg+xml"]
suffixes = ["svg", "abc" ]

In most cases, it will be enough to just change:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffix = "txt"

To:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffixes = ["txt"]
```
So I edited the configuration to support the lastet Hugo version. Hope this enables many new contributors!
