### PR TITLE
Change primary color to increase contrast

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -5,7 +5,7 @@
 
 /* Variables */
 :root {
-  --color-primary: #449999;
+  --color-primary: #367a7a;
   --color-primary-lighter: #999999;
   --color-primary-lightest: #cc9999;
   --color-green: hsl(153, 90%, 30%);


### PR DESCRIPTION
Current primary color (#449999) fail to pass the minimal color contrast for AA level.