### PR TITLE
Add new resources

### DIFF
--- a/content/media.md
+++ b/content/media.md
@@ -30,6 +30,10 @@ title = "Ethical Source in the Media"
 * [Don't Just Do Something, Stand There](https://anonymoushash.vmbrasseur.com/2019/09/22/dont-just-do-something-stand-there/)
 * [Ethical Licensing Talking Points](https://talkingpoints.kemitchell.com/ethical-licenses.html)
 
+## Podcasts
+* ["Creating a Support Network for Maintainers", Sustain](https://sustain.codefund.fm/25)
+* ["Ethical Open Source", Greater Than Code](https://www.greaterthancode.com/ethical-open-source)
+
 ## Conference Talks
 * [The Ethics of Open Source: A Critical Reflection](https://fosdem.org/2020/schedule/event/ethicsoss/) by Don Goodman-Wilson (FOSDEM, February 2 2020)
 * [Bringing Back Ethics to Open Source](https://fosdem.org/2020/schedule/event/ethicsbackinoss/) by Tobie Langel (FOSDEM, February 2 2020)

--- a/content/resources.md
+++ b/content/resources.md
@@ -11,7 +11,7 @@ This page is a list of readings in topics covering Ethical Source, its philosoph
 - [License Zero](https://licensezero.com)
 
 ## Moral and Legal Issues
-- https://opensource.org/faq#evil
+- [Can I stop "evil people" from using my [Open Source] program? No](https://opensource.org/faq#evil)
 - "Open Source is Broken", Don Goodman-Wilson
   - [blog post](https://dev.to/degoodmanwilson/open-source-is-broken-g60)
   - [DevRelCon London 2019](https://www.youtube.com/watch?v=H66-MFR_rgE)
@@ -58,3 +58,4 @@ This page is a list of readings in topics covering Ethical Source, its philosoph
 ## Heroes
 - ["Ethical Source at WeTransfer", Bastiaan Terhorst](https://bastiaan.cc/notes/ethical-source-at-wetransfer/)
 - [Douglas Crockford's JSON license, Wikipedia](https://en.wikipedia.org/wiki/Douglas_Crockford#%22Good,_not_Evil%22)
+- [Seth Vargo Deletes His Code to Protest Its Use by ICE](https://www.wired.com/story/developer-deletes-code-protest-ice/)

--- a/content/resources.md
+++ b/content/resources.md
@@ -1,0 +1,60 @@
++++
+title = "Further Reading"
++++
+
+# A Bibliography of Reading and Resources
+
+This page is a list of readings in topics covering Ethical Source, its philosophical foundations, the history and ideology of Open Source, and a range of closely related literature. Presented in no particular order.
+
+## Alternative Licenses
+- [The Hippocratic License](https://firstdonoharm.dev/)
+- [License Zero](https://licensezero.com)
+
+## Moral and Legal Issues
+- https://opensource.org/faq#evil
+- "Open Source is Broken", Don Goodman-Wilson
+  - [blog post](https://dev.to/degoodmanwilson/open-source-is-broken-g60)
+  - [DevRelCon London 2019](https://www.youtube.com/watch?v=H66-MFR_rgE)
+  - [FOSDEM 2020](https://fosdem.org/2020/schedule/event/ethicsoss/)
+- ["Bringing Back Ethics to Open Source", Tobie Langel](https://fosdem.org/2020/schedule/event/ethicsbackinoss/)
+- ["Building Ethical Software Under Capitalism", Deb Nicholson](https://fosdem.org/2020/schedule/event/capitalismethicaloss/)
+- [_Ruined by Design_, Mike Monteiro](https://www.ruinedby.design)
+- ["Don't Get Distracted", Caleb Thompson](https://www.calebthompson.io/talks/dont-get-distracted/)
+- [The Secretive Company That Might End Privacy as We Know It, New York Times](https://www.nytimes.com/2020/01/18/technology/clearview-privacy-facial-recognition.html)
+- [Dear GitHub 2.0, anonymous](https://github.com/drop-ice/dear-github-2.0)
+- ["Breaking the ICE: How future tech employees could influence government contracts", Erin Paulson](https://www.itpro.co.uk/business-strategy/public-sector/354755/breaking-the-ice-how-future-tech-employees-could-influence)
+- ["Drawing the Ethical Line on Weaponized Deep Learning Research", Carlos E. Perez](https://link.medium.com/ylaE6ekId2)
+- ["Do we need to rethink what free software is?", Matthew Garrett](https://mjg59.dreamwidth.org/52907.html)
+- ["Free as in…?", Luis Villa](https://lu.is/blog/2016/03/23/free-as-in-my-libreplanet-2016-talk/)
+- [The Paradox of Tolerance, Wikipedia](https://en.wikipedia.org/wiki/Paradox_of_tolerance)
+- ["Top 10 FOSS legal developments in 2019", Mark Radcliffe](https://www.synopsys.com/blogs/software-security/top-10-open-source-legal-issues-2019/)
+- [Twitter musings on tech and ICE, Luis Villa](https://twitter.com/luis_in_brief/status/1201933695537467392)
+
+## History and Critique of Open Source
+- ["#wontfix: endorsements can’t fix the Open Source Definition", Kyle E. Mitchell](https://writing.kemitchell.com/2019/04/23/OSD-wontfix.html)
+- ["The Californian Ideology", Richard Barbrook and Andy Cameron](https://www.metamute.org/editorial/articles/californian-ideology)
+- ["Rebuttal of the Californian Ideology", Louis Rossetto](https://www.alamut.com/subj/ideologies/pessimism/califIdeo_II.html)
+- ["Do Artifacts Have Politics?", Langdon Winner](https://www.cc.gatech.edu/~beki/cs4001/Winner.pdf)
+- [_For Fun and Profit: A History of the Free and Open Source Software Revolution_, Christopher Tozzi](https://www.goodreads.com/book/show/36061263-for-fun-and-profit?from_search=true&qid=gh6Oqys482&rank=1)
+- [_Open Standards and the Digital Age: History, Ideology, and Networks_, Andrew L. Russell](https://www.goodreads.com/book/show/21864772-open-standards-and-the-digital-age?from_search=true&qid=EUSm3BHeSh&rank=1)
+- [_Hackers: Heroes of the computer revolution_, Steven Levy](https://www.goodreads.com/book/show/56829.Hackers?from_search=true&qid=sIwEV6y5Wx&rank=1)
+- [_The Open Revolution: Rewrting the Rules of the Information Age_, Rufus Pollock](https://www.goodreads.com/book/show/40515943-the-open-revolution?from_search=true&qid=VHNoWdsYe6&rank=2) ([eBook here](https://openrevolution.net/))
+- [_Rebel Code: Linux and the Open Source Revolution_, Glyn Moody](https://www.goodreads.com/book/show/289947.Rebel_Code?from_search=true&qid=VHNoWdsYe6&rank=1)
+- [_Free Innovation_, Eric von Hippel](https://www.goodreads.com/book/show/33000056-free-innovation?from_search=true&qid=0jTHYQPJiB&rank=1)
+- [_Don't Be Evil: How Big Tech Betrayed Its Founding Principles — and All of Us_, Rana Foroohar](https://www.goodreads.com/book/show/46758636-don-t-be-evil?from_search=true&qid=dbEE79pyrt&rank=1)
+- ["The Complicated Legacy of Stewart Brand’s 'Whole Earth Catalog'", Anna Wiener](https://www.newyorker.com/news/letter-from-silicon-valley/the-complicated-legacy-of-stewart-brands-whole-earth-catalog)
+- ["Open Source Under Attack: How we, the OSI and others can defend it", Chris Aniszczyk, Max Sills, Michael Cheng](https://fosdem.org/2020/schedule/event/osi/)
+- ["Stewart Brand's Whole Earth Catalog, the book that changed the world", Carole Cadwalladr](https://www.theguardian.com/books/2013/may/05/stewart-brand-whole-earth-catalog)
+- ["The Whole Earth Catalog Effect", Steven Kotler](https://www.mnn.com/lifestyle/arts-culture/stories/the-whole-earth-catalog-effect)
+- [_Open Sources: Voices from the Open Source Revolution_, Bruce Perens (ed)](https://www.oreilly.com/openbook/opensources/book/perens.html)
+- ["The Social Meaning of the Personal Computer: Or, Why the Personal Computer Revolution Was No Revolution", Bryan Pfaffenberger](https://www.jstor.org/stable/3317870)
+- [_Cyberselfish: A Critical Romp through the Terribly Libertarian Culture of High Tech_, Paulina Borsook](https://www.goodreads.com/book/show/211081.Cyberselfish_A_Critical_Romp_Through_The_Terribly_Libertarian_Culture_Of_High_Tech?from_search=true&qid=ohIVlJ6frh&rank=1)
+- [_Fire in the Valley: The Making of the Personal Computer_, Michael Swaine, Paul Freiberger](https://www.goodreads.com/book/show/22633290-fire-in-the-valley)
+- ["The Meme Hustler", Evgeny Morozov](https://thebaffler.com/salvos/the-meme-hustler)
+- ["The Economics of Open Source", C J Silverio](https://2019.jsconf.eu/c-j-silverio/the-economics-of-open-source.html)
+- ["The culture war at the heart of open source", Steve Klabnik](https://words.steveklabnik.com/the-culture-war-at-the-heart-of-open-source)
+- ["What comes after 'open source'", Steve Klabnik](https://words.steveklabnik.com/what-comes-after-open-source)
+
+## Heroes
+- ["Ethical Source at WeTransfer", Bastiaan Terhorst](https://bastiaan.cc/notes/ethical-source-at-wetransfer/)
+- [Douglas Crockford's JSON license, Wikipedia](https://en.wikipedia.org/wiki/Douglas_Crockford#%22Good,_not_Evil%22)

--- a/content/resources.md
+++ b/content/resources.md
@@ -59,3 +59,4 @@ This page is a list of readings in topics covering Ethical Source, its philosoph
 - ["Ethical Source at WeTransfer", Bastiaan Terhorst](https://bastiaan.cc/notes/ethical-source-at-wetransfer/)
 - [Douglas Crockford's JSON license, Wikipedia](https://en.wikipedia.org/wiki/Douglas_Crockford#%22Good,_not_Evil%22)
 - [Seth Vargo Deletes His Code to Protest Its Use by ICE](https://www.wired.com/story/developer-deletes-code-protest-ice/)
+- [Kermit is "only for peaceful and humane purposes"](http://www.columbia.edu/kermit/ftp/e/mail.88a)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -60,6 +60,7 @@
         <li><a href="/licenses">Related Licenses</a></li>
         <li><a href="/apply">Working Group</a></li>
         <li><a href="/media">In the Media</a></li>
+        <li><a href="/resources">Further Reading</a></li>
         <li><a href="https://opencollective.com/ethical-source">Donate to Support Our Work</a>
         <li><a href="/contact">Contact Us</a></li>
       </ul>


### PR DESCRIPTION
This is a little bit of a two-fer.

The most important is the creation of a Reading and Resources page for folks to find interesting and engaging literature on ethics, open source, and the intersection of the two

The least important is the addition of a podcast section to the "in the media" page, which contains podcasts that were in my original "reading list", but that I felt didn't belong on the new resources page.