### PR TITLE
Fold source code into the second clause

### DIFF
--- a/content/definition.md
+++ b/content/definition.md
@@ -5,8 +5,8 @@ template = "definition"
 
 Software is considered Ethical Source if it meets the following criteria:
 
-1. It is distributed with source code and can be freely used or combined with other software.
-1. It is developed or maintained in public view and welcoming of public contributions.
+1. It can be freely used or combined with other software.
+1. It is developed or maintained in public view and welcoming of public contributions, which necessarily requires public access to all of the software's source code.
 1. Its community of contributors is governed by a code of conduct that is consistently and fairly enforced.
 1. It is distributed under a license that prohibits the software from being used any individual or organization which directly or indirectly facilitates, encourages, manipulates, coerces, or forces people to engage in behaviors that are in opposition to a specified framework of social good.
 1. Creators have the right to solicit reasonable compensation from any commercial entity that benefits from the software.

--- a/content/definition.md
+++ b/content/definition.md
@@ -6,7 +6,7 @@ template = "definition"
 Software is considered Ethical Source if it meets the following criteria:
 
 1. It can be freely used or combined with other software.
-1. It is developed or maintained in public view and welcoming of public contributions, which necessarily requires public access to all of the software's source code.
+1. The source code is available, developed, and maintained in public view and welcoming of public contributions.
 1. Its community of contributors is governed by a code of conduct that is consistently and fairly enforced.
 1. It is distributed under a license that prohibits the software from being used any individual or organization which directly or indirectly facilitates, encourages, manipulates, coerces, or forces people to engage in behaviors that are in opposition to a specified framework of social good.
 1. Creators have the right to solicit reasonable compensation from any commercial entity that benefits from the software.


### PR DESCRIPTION
1. Accepting contributions in public view requires access to the source code, making this provision more relevant to the second clause than the first.
2. _Distributed with_ implies that software that provides binaries may not be ethical (a binary is not _distributed with_ its corresponding source) which I think was not intentional.