### PR TITLE
📝 Add NPL to the list of ethical licenses

### DIFF
--- a/content/licenses.md
+++ b/content/licenses.md
@@ -9,3 +9,6 @@ heading = "Licensing projects related to ethical source:"
 * [inno3](https://framagit.org/inno3/tm-contract-for-oss-maintainers). A trademark-based contract for OSS maintainers.
 * [Atmosphere Licenses](https://www.open-austin.org/atmosphere-license/about/index.html)
 * [Corporate Accountability Lab (CAL) Ethical IP licencing](https://legaldesign.org/ethical-ip). An overview of IP-related tools for tech workers who care about human rights.
+* [(Cooperative) Non-Violent Public License](https://thufie.lain.haus/NPL.html).
+  -  [The Non-Violent Public License](https://git.pixie.town/thufie/NPL) aims to ensure basic protections against forms of violence, coercion, and discrimination which creations are frequently leveraged for in the modern world. This license covers several formats of creative work but has extra terms for software given the power it has as a tool outside of its creative capacities.
+  - [The Cooperative Non-Violent Public License](https://git.pixie.town/thufie/CNPL) goes further and only allows commercial use of the copyrighted work for individuals and worker-owned organizations. It is a superset of the NPL and contains all of the same terms otherwise.


### PR DESCRIPTION
This is an interesting license that has strong constraints for ethical reasons;
as well as an interesting mechanism for restricting commercial usage to cooperative
enterprises.

I'd need to look into it further before recommending adopting it, but it may  be
worth including in the general list of licenses.