### PR TITLE
Typos in Spanish definition fixed

### DIFF
--- a/content/definition.es.md
+++ b/content/definition.es.md
@@ -2,12 +2,12 @@
 title = "La Definición de Ethical Source"
 +++
 
-El software es considerado un *Ethical source* (fuente ética) si contiene los siguientes cinco criterios:
+El software es considerado una *Ethical source* (fuente ética) si contiene los siguientes cinco criterios:
 
 1. Es libremente distribuido con código fuente y puede ser combinado o usado en conjunción con otro software sin una regalía o cuota.
 2. Es desarrollado en público y tiene un proceso para aceptar contribuciones comunitarias.
-3.  Su comunidad es regida por ún código de conducta que es aplicado de manera consistente y justa.
-4. Sus creadores tienen el derecho de prohibir su uso a individuos o instituciones involucradas en violaciones de los derechos humanos ó otras prácticas que consideren poco éticas.
-5. Sus creadores pueden solicitar una compensación rasonable y voluntaria de las comunidades o instituciones que se beneficien del software.
+3. Su comunidad se rige por un código de conducta que se aplica de manera consistente y justa.
+4. Sus creadores tienen el derecho de prohibir su uso a individuos o instituciones involucradas en violaciones de los derechos humanos u otras prácticas que se consideren poco éticas.
+5. Sus creadores pueden solicitar una compensación razonable y voluntaria a las comunidades o instituciones que se beneficien del software.
 
-La Definición de *Ethical Source* es un documento viviente. La comunidad de la *Ethical Source* es propietaria de esta definición y puede mejorarla y evolucionarla contribuyendo con *issues* y revisiones en [nuestro repositorio de Github](https://github.com/ContributorCovenant/ethicalsource "Ethical Source Definition source code").
+La Definición de *Ethical Source* es un documento vivo. La comunidad de la *Ethical Source* es propietaria de esta definición y puede mejorarla y evolucionarla contribuyendo con *issues* y revisiones en [nuestro repositorio de Github](https://github.com/ContributorCovenant/ethicalsource "Ethical Source Definition source code").


### PR DESCRIPTION
I just discovered the Spanish version of the definition and, as a Spanish native speaker, I have detected some typos that should be addressed to improve the reading. 

Fixed included:

* ```una Ethical source (fuente ética)``` as ```fuente``` is feminine.
* ```se rige``` and ```se aplica``` better than a passive sentence.
* ```un``` which never has an accent.
* ```u otras``` is used when the following word starts with ```o```.
* ```se consideren``` is needed to make sense.
* ```razonable``` is written with ```z```.
* ```a las comunidades``` to express who is paying the compensation.
* ```vivo``` instead of ```viviente```.