### PR TITLE
Simplify the ESD page by moving licensing concerns to their own page.

### DIFF
--- a/content/definition.md
+++ b/content/definition.md
@@ -20,21 +20,6 @@ Ethical Open Source projects are encouraged to use the "Open|Ethical" badge in t
 
 [https://img.shields.io/badge/open-ethical-%234baaaa](https://img.shields.io/badge/open-ethical-%234baaaa)
 
-## Ethically Licensed Open Source
-
-Software is considered **Ethically Licensed Open Source**\* (ELOS) if it meets *any* of the following additional criteria:
-
-* It is distributed under the ["Hippocratic License"](https://firstdonoharm.dev), or a similar license that prohibits the redistribution of the software in modified, derivative, or collected work form from being relicensed to any individual or organization which directly or indirectly facilitates, encourages, manipulates, coerces, or forces people to engage in behaviors that are in conflict with the rights enumerated in the [United Nations Universal Declaration of Human Rights](https://www.un.org/en/universal-declaration-human-rights/).
-* It is distributed under the ["Anti 996" license](https://996.icu/), or a similar license that prohibits the redistribution of the software in modified, derivative, or collected work form to any individual or organization that violates the [International Labor Standards Conventions and/or Recommendations](https://www.ilo.org/global/standards/introduction-to-international-labour-standards/conventions-and-recommendations/lang--en/index.htm) published by the International Labour Organization.
-* It is distributed under an ["Atmosphere" license](https://www.open-austin.org/atmosphere-license/), or a similar license that prohibits the redistribution of the software in modified, derivative, or collected work form to any individual or organization that is materially and directly invested in operations or facilities that have significant negative impact on the global climate response, as [documented by the United Nations Climate Change Secretariat](https://unfccc.int/resource/climateaction2020/media/1308/unfccc_spm_2018.pdf).
-
-\* *The term "open source" in this context refers to the broad experience of public and collaborative software development in contribution to the collective software commons. ELOS software licenses may or may not conform to the Open Source Initiative’s [conventional criteria for open source software licenses](https://opensource.org/osd-annotated).*
-
-Ethically Licensed Open Source projects are encouraged to use the "Licensed Ethically" badge in their project’s documentation: 
-
-![https://img.shields.io/badge/licensed-ethically-%234baaaa](https://img.shields.io/badge/licensed-ethically-%234baaaa) 
-
-[https://img.shields.io/badge/licensed-ethically-%234baaaa](https://img.shields.io/badge/licensed-ethically-%234baaaa)
 
 ## Attribution and Contributions
 Maintaining this definition is the collaborative work of the [Ethical Source Working Group](/apply). Pull requests and issues in our [source code repository](https://github.com/ethicalSource/ethicalsource.dev) are encouraged. Special thanks are extended to [Nate Berkopec](https://nateberkopec.com), [Will Barton](https://github.com/willbarton/), [Steve Phillips](https://tryingtobeawesome.com), and [Madalyn Parker](https://twitter.com/madalynrose) for their contributions.

--- a/content/licenses.md
+++ b/content/licenses.md
@@ -1,6 +1,6 @@
 +++
-title = "Related Licenses"
-heading = "Licensing projects related to ethical source:"
+title = "Ethical Licenses"
+heading = "Ethical Open Source Licenses"
 +++
 
 * [Hippocratic License](https://firstdonoharm.dev). A license that prohibits use of the software to violate international human rights guidelines.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -56,7 +56,7 @@
       <ul>
         <li><a href="/definition">Ethical Source Definition</a></li>
         <li><a href="/translations">Definition Translations</a></li>
-        <li><a href="/licenses">Related Licenses</a></li>
+        <li><a href="/licenses">Ethical Licenses</a></li>
         <li><a href="/apply">Join the Working Group</a></li>
         <li><a href="/media">In the Media</a></li>
         <li><a href="/blog">Blog</a></li>


### PR DESCRIPTION
To keep the distinction clear between Ethical Open Source projects and Ethically Licensed Open Source projects, I moved all mention of licenses to a separate page.