### PR TITLE
Add The Katharos License

### DIFF
--- a/content/licenses.md
+++ b/content/licenses.md
@@ -12,3 +12,4 @@ heading = "Ethical Open Source Licenses"
 * [(Cooperative) Non-Violent Public License](https://thufie.lain.haus/NPL.html).
   -  [The Non-Violent Public License](https://git.pixie.town/thufie/NPL) aims to ensure basic protections against forms of violence, coercion, and discrimination which creations are frequently leveraged for in the modern world. This license covers several formats of creative work but has extra terms for software given the power it has as a tool outside of its creative capacities.
   - [The Cooperative Non-Violent Public License](https://git.pixie.town/thufie/CNPL) goes further and only allows commercial use of the copyrighted work for individuals and worker-owned organizations. It is a superset of the NPL and contains all of the same terms otherwise.
+- [Katharos License](https://github.com/katharostech/katharos-license). A license designed to protect the work from being used to promote or produce suggestive and/or explicit content.


### PR DESCRIPTION
This adds my organization's new [Katharos License](https://github.com/katharostech/katharos-license) to the license list. If there is review required or extra criteria for a license appearing in this list just let me know. I figured a PR was the easiest way to open the discussion. The [README](https://github.com/katharostech/katharos-license) or the license preamble pretty much gives the outline of the license and its purpose. Let me know if you have any questions! :smiley: