### PR TITLE
Share the names of our leadership team on the governance page.

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -4,7 +4,7 @@ title = "Governance"
 
 ## Organization for Ethical Source
 
-Ahead of a General Assembly and election of additional Committee members later this year, governance of the organization is the responsibility of its three Founding Members: Coraline Ada Ehmke, Don Goodman-Wilson, and Tobie Langel.
+Ahead of a [general assembly](/statutes#general-assembly) and election of additional committee members later this year, the [committee](/statutes#committee) is currently composed of the organization's founding members: Coraline Ada Ehmke, Don Goodman-Wilson, and Tobie Langel.
 
 * Bylaws ([English](/statutes) | [Français](/fr/statuts))
 * Code of Conduct ([English](/community-code-of-conduct) | [Français](/fr/code-de-conduite))

--- a/content/governance.md
+++ b/content/governance.md
@@ -4,8 +4,7 @@ title = "Governance"
 
 ## Organization for Ethical Source
 
+Ahead of a General Assembly and election of additional Committee members later this year, governance of the organization is the responsibility of its three Founding Members: Coraline Ada Ehmke, Don Goodman-Wilson, and Tobie Langel.
+
 * Bylaws ([English](/statutes) | [Français](/fr/statuts))
-
-## Ethical Source Working Group
-
 * Code of Conduct ([English](/community-code-of-conduct) | [Français](/fr/code-de-conduite))


### PR DESCRIPTION
Cat Allman (@catallman) pointed out that the names of the OES leaders weren't on the web site. 