### PR TITLE
Opt out of Federated Learning of Cohorts

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,3 @@
+/*
+  # Block Google FLoC
+  Permissions-Policy: interest-cohort=()


### PR DESCRIPTION
Add the `Permissions-Policy: interest-cohort=()` HTTP response header to opt out of participation in Google FLoC on ethicalsource.dev.

FLoC compromises user privacy. See the [EFF's writeup](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea) for more details.