### PR TITLE
Replace local URL for RightsCon talk with link to archive.org

### DIFF
--- a/content/talks/will-behave-for-code-rightscon.md
+++ b/content/talks/will-behave-for-code-rightscon.md
@@ -3,7 +3,8 @@ title = "Will Behave For Code: How Ethical Software Licensing Can Combat Human R
 summary = "RightsCon 2022 (June 8, 2022)"
 slug = "will-behave-for-code-rightscon"
 type = "talks"
-targetUrl = "/video/will_behave_for_code.mp4"
+targetUrl = "https://archive.org/details/oes-will-behave-for-code"
+aliases = ["/video/will_behave_for_code.mp4"]
 targetAnchor = "Watch the Video"
 thumbnail = ""
 +++

--- a/content/talks/will-behave-for-code-rightscon.md
+++ b/content/talks/will-behave-for-code-rightscon.md
@@ -4,7 +4,6 @@ summary = "RightsCon 2022 (June 8, 2022)"
 slug = "will-behave-for-code-rightscon"
 type = "talks"
 targetUrl = "https://archive.org/details/oes-will-behave-for-code"
-aliases = ["/video/will_behave_for_code.mp4"]
 targetAnchor = "Watch the Video"
 thumbnail = ""
 +++


### PR DESCRIPTION
# What does the PR accomplish?
* Link to a higher-quality video of the RightsCon 2022 talk

# Interesting bits
* We'll need to keep the local, low-quality video for a while, because it is referenced by URL in a grantee report

# What I need help with
* If someone wants to look at rewrite rules on netlify, we may be able to redirect the previous url
