### PR TITLE
Fix missing alt tags for shortcode-related images.

### DIFF
--- a/layouts/partials/floating-card.html
+++ b/layouts/partials/floating-card.html
@@ -7,7 +7,7 @@
   <article>
   <div class="thumbnail">
     <a href="{{ .Params.targetUrl }}">
-    <img src="/images/{{ $thumbnail }}" class="thumbnail" />
+    <img src="/images/{{ $thumbnail }}" class="thumbnail" alt="{{ .Params.title }} image or logo used as a thumbnail for visual interest." />
     </a>
   </div>
   <h3>

--- a/layouts/partials/portrait.html
+++ b/layouts/partials/portrait.html
@@ -1,7 +1,7 @@
 {{ $image := or .Params.image "geometric.jpg" }}
 <li>
   <div class="portrait">
-    <a href="/who-we-are/people/{{ .Params.slug }}"><img src="/images/people/{{ $image }}" /></a>
+    <a href="/who-we-are/people/{{ .Params.slug }}"><img src="/images/people/{{ $image }}" alt="Headshot of {{ .Params.name }}" /></a>
   </div>
   <h3>
     <a href="/who-we-are/people/{{ .Params.slug }}" class="bio-link">{{ .Params.name }}</a>

--- a/layouts/shortcodes/media-link.html
+++ b/layouts/shortcodes/media-link.html
@@ -4,7 +4,7 @@
     <svg class="media-node">
       <use xlink:href="/images/decorations/svg/media-node.svg#circle"></use>
     </svg>
-    <img src="/images/logos/media/{{ $publogo }}" class="media-logo" />
+    <img src="/images/logos/media/{{ $publogo }}" class="media-logo" alt="Logo for {{ .Params.publication }}" />
     <h3>
       <a href="{{ .Params.url }}">
         {{ .Params.title }}

--- a/layouts/who-we-are/single.html
+++ b/layouts/who-we-are/single.html
@@ -2,7 +2,7 @@
 <section>
 
   <div class="bio-pic">
-    <img src="/images/people/{{ .Params.image }}">
+    <img src="/images/people/{{ .Params.image }}" alt="Photograph of {{ .Params.Name }}">
     <p>{{ .Params.Name }} ({{ .Params.Pronouns }})</p>
   </div>
 


### PR DESCRIPTION
# What does this PR accomplish?
* It fixes an issue of missing alt tags from templated HTML fragments

# Getting there
* In most cases, it was a matter of passing `Params.name` through to the alt tag.

# Notes for reviewers
* I'm curious about whether we should provide descriptive text for photos of individuals?