### PR TITLE
Add Ethical Terms of Service project to “What We Do” page

### DIFF
--- a/content/projects/ethical-tos.md
+++ b/content/projects/ethical-tos.md
@@ -1,0 +1,15 @@
++++
+title = "Ethical Terms of Service (ToS)"
+summary = "A toolkit designed to help people operating small platforms protect their communities."
+slug = "ethical-tos"
+destination = "https://ethical-tos.dev"
+type = "projects"
++++
+
+OES is developing an Ethical ToS ("Terms of Service") toolkit designed for people operating small platforms, for example ActivityPub implementations including Mastodon instances, discussion forums, and other online community spaces.
+
+The Ethical ToS is meant to be a starting point for continuous processes of improvement, not an ending point or a solution. Adopting and adapting the Ethical ToS will signal that the platform has given substantial thought to a plan for protecting their community from harmful and possibly illegal actions– and that the platform will work to ensure that the ToS is not weaponized against vulnerable users.
+
+Are you interested in helping us develop the Ethical ToS toolkit? [Become an OES member](/join) and join the OSC working group.
+
+{{< call-to-action-bottom heading="Want to learn more?" anchor="Visit the Ethical ToS website" url="https://ethical-tos.dev" >}}

--- a/content/what-we-do/_index.html
+++ b/content/what-we-do/_index.html
@@ -38,6 +38,9 @@ kicker = "Collaborating across disciplines and around the world on a shared visi
       {{< hero slug="open-social-compact" type="projects" context="takeover" image="" >}}
     </li>
     <li>
+      {{< hero slug="ethical-tos" type="projects" context="takeover" image="" >}}
+    </li>
+    <li>
       {{< hero slug="ethical-edtech" type="projects" context="takeover" image="" >}}
     </li>
   </ul>


### PR DESCRIPTION
# What does this PR accomplish?
* Shares information about the new Ethical ToS working group.

# Getting there
* Added a `.md` summary in the `projects/` folder

# Notes for reviewers
* I used the copy from https://ethical-tos.dev for the explainer-- edits & suggestions welcome